### PR TITLE
Fix sign handling in Saptavargaja Bala

### DIFF
--- a/saptavargaja/saptavargaja_bala.py
+++ b/saptavargaja/saptavargaja_bala.py
@@ -25,9 +25,19 @@ def calculate_saptavargaja_bala(chart):
             varga_signs = calculate_varga_chart(chart, division, rules)
 
         for graha, sign in varga_signs.items():
+            # ``calculate_varga_chart`` returns a dictionary containing both the
+            # division number and the sign, while the ``same_as_sign`` path
+            # above yields just the sign string.  ``get_dignity`` expects only
+            # the sign name, so handle both cases here.
+            if isinstance(sign, dict):
+                sign_name = sign.get("sign")
+            else:
+                sign_name = sign
+
             if graha not in dignity_table:
                 dignity_table[graha] = []
-            dignity = get_dignity(graha, sign)
+
+            dignity = get_dignity(graha, sign_name)
             dignity_table[graha].append(dignity_scores.get(dignity, 0))
 
     saptavarga_bala = {g: {


### PR DESCRIPTION
## Summary
- handle varga chart dictionary structure in `calculate_saptavargaja_bala`

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
from generate_rasi_chart import generate_rasi_chart
from saptavargaja.saptavargaja_bala import calculate_saptavargaja_bala
chart = generate_rasi_chart("1990-05-15", "14:30", 28.6139, 77.2090)
result = calculate_saptavargaja_bala(chart)
print(result)
PY`


------
https://chatgpt.com/codex/tasks/task_e_687a303a033483328882f2c05c700e2d